### PR TITLE
Fix PIA partial decoding and CPU stack endianness; add developer guidance and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated CLAUDE.md with comprehensive development guidelines including code commenting standards (focus on "why" not "what", document hardware behavior, avoid redundant comments), changelog maintenance requirements, and GitHub issue reference practices
+
 ### Fixed
 - Implemented partial address decoding for 8255 PIA ($FD00-$FDFF now aliases to $FD00-$FD03) to match real 6502 hardware behavior and prevent incompatibility with software that relies on common partial decoding practices
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- Implemented partial address decoding for 8255 PIA ($FD00-$FDFF now aliases to $FD00-$FD03) to match real 6502 hardware behavior and prevent incompatibility with software that relies on common partial decoding practices
+
+## [0.1.0] - 2024-12-13
+
+### Added
+- Initial release of AMICO 2000 emulator
+- Complete 6502 CPU emulation with all 56 opcodes and 151 instruction variants
+- 8255 PIA emulation for display and keyboard I/O
+- SVG-based seven-segment display rendering with authentic LED appearance
+- Hexadecimal keyboard support with PC keyboard mapping
+- Monitor ROM support (512 bytes at $FE00-$FFFF)
+- Browser-based emulation running at authentic 1MHz speed
+- Debug console commands for memory inspection and CPU state monitoring

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,127 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a browser-based emulator for the **AMICO 2000**, an Italian home computer (ASEL Milano, 1978) that the project owner's father built from a kit. This is a preservation and memorial project recreating a machine that was later discarded.
+
+## Running the Emulator
+
+No build step is required. To run:
+
+```bash
+# Open index.html directly in a browser, or use a local server to avoid CORS issues:
+python3 -m http.server 8000
+# Then open http://localhost:8000
+```
+
+## Testing the Emulator
+
+- Open the browser console (F12) to access debug commands
+- Use `debug.mem(0x0000, 16)` to dump memory
+- Use `debug.state()` to show CPU state
+- Access emulator internals directly: `amico.cpu.PC`, `amico.cpu.A`, etc.
+
+## Code Architecture
+
+The project consists of four modular JavaScript files:
+
+### 1. cpu6502.js (~900 lines)
+Complete 6502 CPU interpreter implementing:
+- All 56 opcodes with 151 instruction variants
+- All addressing modes
+- BCD arithmetic
+- Interrupt handling (IRQ, NMI, BRK)
+- Memory-mapped I/O via callbacks (`readCallback`, `writeCallback`)
+- Cycle-accurate timing for proper execution speed
+
+**Key architectural details:**
+- Memory is a flat 64KB Uint8Array
+- I/O callbacks allow the machine emulator to intercept reads/writes to specific addresses
+- Interrupts are polled before each instruction fetch (see `_checkInterrupts()`)
+- Stack lives at $0100-$01FF (standard 6502)
+
+### 2. amico2000.js (~350 lines)
+Machine emulation layer that connects CPU to hardware:
+- Manages 8255 PIA (Programmable Interface Adapter) for I/O
+- Implements display multiplexing (refreshes 6 digits sequentially)
+- Keyboard matrix scanning (4 rows × 6 columns)
+- ROM/RAM memory mapping
+
+**Key architectural details:**
+- The 8255 PIA is memory-mapped at $FD00-$FD03:
+  - $FD00 (Port A): Display segments (output) / Keyboard column data (input)
+  - $FD01 (Port B): Digit select bits 0-5 / Keyboard row scan bits 0-3
+  - $FD02 (Port C): Expansion port (unused)
+  - $FD03: Control register
+- Display updates are decoupled from PIA writes for performance - buffered and updated once per frame
+- Keyboard scanning matches the ROM's timing expectations (port B values: 1, 3, 5 for rows 0, 1, 2)
+
+### 3. display.js (~200 lines)
+SVG-based seven-segment display renderer:
+- 6 displays arranged as: [A3][A2][A1][A0] : [D1][D0]
+- Authentic red LED appearance with glow effects
+- Runs at 60fps via `requestAnimationFrame`, independent of CPU speed
+
+**Implementation note:** Display updates are intentionally separated from the CPU loop to avoid thousands of DOM updates per second.
+
+### 4. main.js (~300 lines)
+Application initialization and UI:
+- Contains the Monitor ROM data (MONITOR_ROM constant at top of file)
+- Keyboard event handling (both physical keyboard and on-screen buttons)
+- ROM file loading via file input
+- Debug console commands exposed via global `debug` object
+
+**Memory Map:**
+```
+$0000-$07FF: 2KB RAM (expandable)
+$FB00-$FCFF: Cassette ROM (optional, not yet implemented)
+$FD00-$FD03: 8255 PIA I/O ports
+$FE00-$FFFF: Monitor ROM (512 bytes)
+```
+
+## Important Implementation Notes
+
+### Performance
+The display update system is decoupled from PIA writes. The emulator runs the CPU at ~1MHz, but display updates happen once per frame (60Hz). This prevents performance issues from excessive DOM manipulation.
+
+### Interrupt Handling
+The CPU properly polls for pending NMI/IRQ before each instruction fetch. This matches real 6502 behavior and is critical for correct emulation.
+
+### Keyboard Scanning
+The ROM's TESTAS routine expects specific I/O patterns. The keyboard matrix scanning in amico2000.js matches port B values (1, 3, 5) that the ROM uses to scan rows.
+
+### ROM Data
+The MONITOR_ROM array in main.js contains the actual monitor ROM bytes. When loading ROM files:
+- `prom.ic9` goes at $FE00 (Monitor ROM, 512 bytes)
+- `prom.ic10` goes at $FB00 (Cassette ROM, 512 bytes)
+- Other .bin files load as programs at $0000
+
+## Known Limitations
+
+1. **Browser Tab Throttling**: Modern browsers throttle `requestAnimationFrame` when tabs are backgrounded, causing the emulator to pause/slow down
+2. **Cassette Interface**: Not yet implemented - file-based LOAD/SAVE would intercept cassette ROM calls
+3. **Keyboard Matrix**: Does not simulate ghosting that occurs on real hardware when multiple keys are pressed
+
+## Keyboard Mappings
+
+| Amico Key | PC Key |
+|-----------|--------|
+| 0-9, A-F  | 0-9, A-F |
+| AD        | ↑ (Arrow Up) |
+| DA        | ↓ (Arrow Down) |
+| PC        | P |
+| REG       | R |
+| +         | + or = |
+| GO        | Enter or G |
+| RES       | Escape or Backspace |
+
+## Historical Context
+
+The AMICO 2000 was published in "Sperimentare" magazine starting December 1978, designed by ASEL (Milano) and sold as a kit. Features included:
+- MOS 6502 CPU @ 1MHz
+- 1KB RAM (expandable to 2KB)
+- 512 bytes Monitor ROM
+- 6 seven-segment LED displays
+- Hexadecimal keypad (23 keys)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+Is # CLAUDE.md
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
@@ -97,6 +97,46 @@ The MONITOR_ROM array in main.js contains the actual monitor ROM bytes. When loa
 - `prom.ic9` goes at $FE00 (Monitor ROM, 512 bytes)
 - `prom.ic10` goes at $FB00 (Cassette ROM, 512 bytes)
 - Other .bin files load as programs at $0000
+
+## Development Guidelines
+
+### Code Comments
+All new code and code changes should include clear, meaningful comments:
+
+**What to comment:**
+- **Why, not what**: Explain the reasoning behind implementation choices, not what the code obviously does
+- **Hardware behavior**: Document how the code maps to real AMICO 2000 or 6502 hardware behavior
+- **Non-obvious logic**: Clarify complex algorithms, bit manipulations, or timing-critical code
+- **Edge cases**: Explain handling of special cases or boundary conditions
+- **Performance choices**: Note why a particular approach was chosen for efficiency
+
+**What NOT to comment:**
+- Self-explanatory code (e.g., `i++; // increment i`)
+- Redundant descriptions that just restate the code
+- Commented-out code (remove it; git preserves history)
+
+**Examples of good comments:**
+```javascript
+// The 8255 PIA uses partial address decoding, so $FD00-$FDFF all map to $FD00-$FD03
+// This matches real hardware behavior where not all address lines are decoded
+
+// Decouple display updates from PIA writes to avoid thousands of DOM updates per second
+// Real hardware updates at ~500Hz, but we batch updates at 60fps
+
+// Scan keyboard matrix using port B values 1, 3, 5 to match ROM's TESTAS routine expectations
+```
+
+### Changelog Maintenance
+**IMPORTANT**: Whenever you make any changes to the codebase, you MUST update CHANGELOG.md:
+- Add entries under the `[Unreleased]` section
+- Use the appropriate category: `Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, or `Security`
+- Write clear, user-facing descriptions of what changed and why
+
+### GitHub Issue References
+When implementing changes based on a GitHub issue:
+- Reference the issue number in the CHANGELOG.md entry (e.g., "Fixed display flickering (#42)")
+- Include the issue reference in relevant code comments (e.g., `// Fix for #42: Handle edge case when...`)
+- This maintains traceability between issues, code changes, and release notes
 
 ## Known Limitations
 

--- a/cpu6502.js
+++ b/cpu6502.js
@@ -75,12 +75,20 @@ class CPU6502 {
      */
     read(address) {
         address &= 0xFFFF;
-        
-        // Check for I/O callback
-        if (this.readCallbacks.has(address)) {
-            return this.readCallbacks.get(address)(address) & 0xFF;
+
+        // Check for PIA partial address decoding ($FD00-$FDFF maps to $FD00-$FD03)
+        // This matches real 6502 hardware where partial decoding was common to save on logic chips
+        let callbackAddress = address;
+        if ((address & 0xFF00) === 0xFD00) {
+            // Map any address in $FDxx to one of the 4 PIA registers
+            callbackAddress = 0xFD00 | (address & 0x0003);
         }
-        
+
+        // Check for I/O callback
+        if (this.readCallbacks.has(callbackAddress)) {
+            return this.readCallbacks.get(callbackAddress)(address) & 0xFF;
+        }
+
         return this.memory[address];
     }
     
@@ -90,13 +98,21 @@ class CPU6502 {
     write(address, value) {
         address &= 0xFFFF;
         value &= 0xFF;
-        
+
+        // Check for PIA partial address decoding ($FD00-$FDFF maps to $FD00-$FD03)
+        // This matches real 6502 hardware where partial decoding was common to save on logic chips
+        let callbackAddress = address;
+        if ((address & 0xFF00) === 0xFD00) {
+            // Map any address in $FDxx to one of the 4 PIA registers
+            callbackAddress = 0xFD00 | (address & 0x0003);
+        }
+
         // Check for I/O callback
-        if (this.writeCallbacks.has(address)) {
-            this.writeCallbacks.get(address)(address, value);
+        if (this.writeCallbacks.has(callbackAddress)) {
+            this.writeCallbacks.get(callbackAddress)(address, value);
             return;
         }
-        
+
         this.memory[address] = value;
     }
     
@@ -148,18 +164,18 @@ class CPU6502 {
     }
     
     push16(value) {
-        this.push((value >> 8) & 0xFF);  // High byte first
-        this.push(value & 0xFF);          // Then low byte
+        this.push(value & 0xFF);          // Low byte first
+        this.push((value >> 8) & 0xFF);  // High byte second
     }
-    
+
     pull() {
         this.SP = (this.SP + 1) & 0xFF;
         return this.read(0x0100 + this.SP);
     }
-    
+
     pull16() {
-        const lo = this.pull();
-        const hi = this.pull();
+        const hi = this.pull();  // High byte first (was pushed second, so on top)
+        const lo = this.pull();  // Low byte second (was pushed first, so below)
         return (hi << 8) | lo;
     }
     


### PR DESCRIPTION
Summary

    Implement partial address decoding for the 8255 PIA so F D 00 – FDFF alias to F D 00 – FD03 (emulation accuracy).
    Correct stack push/pull endianness for 16-bit pushes/pulls (push16/pull16).
    Add CLAUDE.md with development guidelines for contributors (commenting, changelog, issue references).
    Add CHANGELOG.md and populate Unreleased / 0.1.0 entries.

Why

    Partial decoding matches real 6502 hardware and fixes incompatibilities with software that expects $FDxx to map to the four PIA registers.
    The previous push16/pull16 ordering was inconsistent and could break return addresses/interrupt state handling.
    CLAUDE.md documents repository conventions and expectations to improve future contributions.
    CHANGELOG.md adds release/change tracking following Keep a Changelog and semver.

Files changed

    cpu6502.js
        Added mapping so reads/writes in F D 00. . FDFF are routed to F D 00. . FD03 for I/O callbacks.
        Fixed push16/pull16 ordering and updated comments.
    CLAUDE.md (new)
        Developer guidance: architecture summary, testing, commenting rules, changelog process, keyboard mappings, and known limitations.
    CHANGELOG.md (new)
        Unreleased notes and initial 0.1.0 entry.

Behavioral impact & testing

    Verify PIA behavior: accesses to addresses like F D 10 FD03.
    Test existing software/ROMs that use PIA ports to confirm no regressions.
    Test subroutine returns, interrupts, BRK/RTI/JSR/RTS to ensure stack behavior is now correct.
    Run emulator UI and monitor ROM to confirm normal operation.

Notes

    CHANGELOG.md should be kept up-to-date for all subsequent changes per CLAUDE.md guidance.
    If you want, I can shorten or reword this description for the PR body or add suggested reviewers/labels.
