### PR TITLE
Document .bin program loader reset behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   keyboard-matrix caveats, and CPU verification work.
 - Moved the Gemini and Opus review notes into `archived/` so root-level
   documentation stays focused on active project guidance.
+- Clarified that loading a raw `.bin` program at $0000 via the file loader
+  preserves machine state and intentionally does not call `amico.reset()`,
+  because `Amico2000.reset()` clears all 2KB of RAM ($0000-$07FF) and would
+  erase the program just loaded. The other load paths (monitor ROM, cassette
+  ROM, 512-byte fallback) write to ROM regions unaffected by reset, so they
+  continue to reset after loading. This documents the asymmetry introduced
+  in #21 and resolves #25.
 
 ### Fixed
 - Fixed decimal-mode ADC/SBC flag behavior so binary-derived flags and BCD carry

--- a/main.js
+++ b/main.js
@@ -304,8 +304,8 @@ function setupFileLoader() {
                 // Load as program at $0000.
                 // Intentionally no amico.reset() here: Amico2000.reset() zeroes
                 // all 2KB of RAM ($0000-$07FF), which would erase the program
-                // we just wrote. The other load paths target ROM regions that
-                // reset() does not touch, so they reset safely. See #25.
+                // we just wrote. The ROM and 512-byte fallback paths target
+                // regions reset() does not touch, so they reset safely. See #25.
                 amico.loadProgram(rom, 0x0000);
                 console.log('Program loaded at $0000:', file.name);
             }

--- a/main.js
+++ b/main.js
@@ -301,7 +301,11 @@ function setupFileLoader() {
                 console.log('ROM loaded as monitor:', file.name);
                 amico.reset();
             } else {
-                // Load as program at $0000
+                // Load as program at $0000.
+                // Intentionally no amico.reset() here: Amico2000.reset() zeroes
+                // all 2KB of RAM ($0000-$07FF), which would erase the program
+                // we just wrote. The other load paths target ROM regions that
+                // reset() does not touch, so they reset safely. See #25.
                 amico.loadProgram(rom, 0x0000);
                 console.log('Program loaded at $0000:', file.name);
             }


### PR DESCRIPTION
## Summary

- Document that raw `.bin` program loads intentionally skip `amico.reset()` because reset clears RAM at `$0000-$07FF`
- Clarify the source comment so only ROM and 512-byte fallback load paths are described as safe to reset after loading

## Verification

- `node --check main.js`

Resolves #25.